### PR TITLE
Use CFBundleShortVersionString

### DIFF
--- a/src/ios/AppVersion.m
+++ b/src/ios/AppVersion.m
@@ -7,7 +7,7 @@
 {
 
     NSString* callbackId = command.callbackId;
-    NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+    NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
 
     CDVPluginResult* pluginResult = nil;
     NSString* javaScript = nil;


### PR DESCRIPTION
CFBundleShortVersionString returns the version. CFBundleVersion returns build number. Cordova updates CFBundleShortVersionString.
