### PR TITLE
Inject $q for AngularJS promises

### DIFF
--- a/www/AppVersionPlugin.js
+++ b/www/AppVersionPlugin.js
@@ -5,6 +5,8 @@ var getAppVersion = function (success, fail) {
     if(window.jQuery){
       dfr = jQuery.Deferred();
     } else if(window.angular){
+      var injector = angular.injector(["ng"]);
+      var $q = injector.get("$q");
       dfr = $q.defer();
     } else {
       return console.error('AppVersion either needs a success callback, or jQuery/AngularJS defined for using promises');


### PR DESCRIPTION
My bad for forgetting to inject it in my last pull-request, I was testing the code within an AngularJS provider so I didn't realize `$q` of course wouldn't be defined in the global scope where this plugin would be run.

This should fix it by injecting `$q` if angular is defined.

---

Closes #19
/cc @vladipus @3melectronicmonitoring
