### PR TITLE
Return promise when using Angular

### DIFF
--- a/www/AppVersionPlugin.js
+++ b/www/AppVersionPlugin.js
@@ -1,22 +1,24 @@
 // Returns a jQuery or AngularJS deferred object, or pass a success and fail callbacks if you don't want to use jQuery or AngularJS
 var getAppVersion = function (success, fail) {
-  var dfr;
+  var toReturn, deferred;
   if ((typeof success) === 'undefined') {
     if(window.jQuery){
-      dfr = jQuery.Deferred();
+      deferred = jQuery.Deferred();
+      toReturn = deferred;
     } else if(window.angular){
       var injector = angular.injector(["ng"]);
       var $q = injector.get("$q");
-      dfr = $q.defer();
+      deferred = $q.defer();
+      toReturn = deferred.promise
     } else {
       return console.error('AppVersion either needs a success callback, or jQuery/AngularJS defined for using promises');
     }
-    success = dfr.resolve;
-    fail = dfr.reject;
+    success = deferred.resolve;
+    fail = deferred.reject;
   }
   // 5th param is NOT optional. must be at least empty array
   cordova.exec(success, fail, "AppVersion", "getVersionNumber", []);
-  return dfr;
+  return toReturn;
 };
 
 module.exports = getAppVersion;


### PR DESCRIPTION
Breaking change! Returning the promise instead of the deferred should be preferred, as the promise is then()'able and this results in the same usage pattern as the jQuery case. Also, I don't think the deferred should be exposed. The Angular $q deferred is not then()'able, so you're required to use `cordova.getAppVersion().promise.then()`.
