### PR TITLE
Properly invoke provided callbacks in proxy

### DIFF
--- a/www/blackberry10/AppVersionProxy.js
+++ b/www/blackberry10/AppVersionProxy.js
@@ -1,5 +1,16 @@
 module.exports = {
-    getVersionNumber: function() {
+    getVersionNumber: function( success, fail ) {
+        if( !blackberry || !blackberry.app || !blackberry.app.version ) {
+            if( fail ) {
+                return fail();
+            } else {
+                return "";
+            }
+        }
+
+        if( success ) {
+            return success( blackberry.app.version );
+        }
         return blackberry.app.version;
     }
 };


### PR DESCRIPTION
The previous version did not properly use the provided callbacks to return the result. This caused the version to not be returned.
