### PR TITLE
Ios fallback

### DIFF
--- a/src/ios/AppVersion.m
+++ b/src/ios/AppVersion.m
@@ -8,6 +8,14 @@
 
     NSString* callbackId = command.callbackId;
     NSString* version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    if (version == nil) {
+      NSLog(@"CFBundleShortVersionString was nil, attempting CFBundleVersion");
+      version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+      if (version == nil) {
+        NSLog(@"CFBundleVersion was also nil, giving up");
+        // not calling error callback here to maintain backward compatibility
+      }
+    }
 
     CDVPluginResult* pluginResult = nil;
     NSString* javaScript = nil;


### PR DESCRIPTION
Hi, to end all discussion about which version to use, we could test for 'nil' and try the alternative version property. This doesn't break current usage and offers a solution for build tools apparently not specifying the correct plist property.
