### PR TITLE
iOS: getAppName to return localized value (like Android)

### DIFF
--- a/src/ios/AppVersion.m
+++ b/src/ios/AppVersion.m
@@ -6,7 +6,7 @@
 - (void)getAppName : (CDVInvokedUrlCommand *)command
 {
     NSString * callbackId = command.callbackId;
-    NSString * version =[[[NSBundle mainBundle]infoDictionary]objectForKey :@"CFBundleDisplayName"];
+    NSString * version =[[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:@"CFBundleDisplayName"];
     CDVPluginResult * pluginResult =[CDVPluginResult resultWithStatus : CDVCommandStatus_OK messageAsString : version];
     [self.commandDelegate sendPluginResult : pluginResult callbackId : callbackId];
 }


### PR DESCRIPTION
Fix #126 

This plugin's iOS `#getAppName` [current implementation](https://github.com/sampart/cordova-plugin-app-version/blob/master/src/ios/AppVersion.m#L6) is using [`infoDictionary`](https://developer.apple.com/documentation/foundation/nsbundle/1413477-infodictionary), and should switch to [`localizedInfoDictionary`](https://developer.apple.com/documentation/foundation/nsbundle/1407645-localizedinfodictionary) to get localized value instead.

Same situation described in https://stackoverflow.com/questions/9155985/how-to-get-localized-cfbundledisplayname,
with 2 solutions both working great:
- `[[[NSBundle mainBundle] localizedInfoDictionary] objectForKey:@"CFBundleDisplayName"]`
⇒ gone for this one, as all other methods follow this same structure
- `[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]`
(see [objectForInfoDictionaryKey](https://developer.apple.com/documentation/foundation/nsbundle/1408696-objectforinfodictionarykey))